### PR TITLE
Add tagging of IOCs with hits

### DIFF
--- a/iris_misp_module/IrisMISPConfig.py
+++ b/iris_misp_module/IrisMISPConfig.py
@@ -20,7 +20,7 @@
 module_name = "IrisMISP"
 module_description = "Provides an interface between MISP and IRIS"
 interface_version = "1.2.0"
-module_version = "1.3.0"
+module_version = "1.4.0"
 pipeline_support = False
 pipeline_info = {}
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='iris_misp_module',
-    version='1.3.0',
+    version='1.4.0',
     packages=['iris_misp_module', 'iris_misp_module.misp_handler'],
     url='https://github.com/dfir-iris/iris-misp-module',
     license='LGPLv3.0',
@@ -17,6 +17,6 @@ setup(
     install_requires=[
         "setuptools",
         "pyunpack",
-        "pymisp==2.4.172"
+        "pymisp==2.4.187"
     ]
 )


### PR DESCRIPTION
This PR adds functionality to automatically add a tag called 'misp:hit' if there is any result in the MISP response. This helps to easier see which IOCs are matching with one of the configured MISP instances.

Furthermore it de-duplicates a bit of the code. All the methods to generate the html reports are effectively the same, so I made 1 method to do this, as well as for processing the response of MISP itself.